### PR TITLE
Make responsive options respect global options properties

### DIFF
--- a/src/ts/option/options.ts
+++ b/src/ts/option/options.ts
@@ -27,16 +27,15 @@ module latte {
                 return;
             }
 
-            // Copy properties
-            for (const key in options) {
-                if (options.hasOwnProperty(key) && key !== "responsive") {
-                    (this as any)[key] = (options as any)[key];
+            for (const prop in options) {
+                if (options.hasOwnProperty(prop) && prop !== "responsive") {
+                    (this as any)[prop] = (options as any)[prop];
                 }
             }
 
             // Copy responsive properties
             if (options.responsive != null) {
-                this.responsive = new ResponsiveMap(options.responsive);
+                this.responsive = new ResponsiveMap(options.responsive, this);
             }
         }
 

--- a/src/ts/option/responsive-map.ts
+++ b/src/ts/option/responsive-map.ts
@@ -12,17 +12,27 @@ module latte {
         /**
          * Creates an instance of ResponsiveMap.
          * @param {ResponsiveMap} [map] Map to copy properties.
+         * @param {Options} [globalOptions] Options to use as default.
          * @memberof ResponsiveMap
          */
-        constructor(map?: ResponsiveMap) {
+        constructor(map?: ResponsiveMap, globalOptions?: Options) {
             if (map == null) {
                 return;
             }
 
-            // Copy properties
-            for (const key in map) {
-                if (map.hasOwnProperty(key)) {
-                    (this as any)[key] = new Options((map as any)[key]);
+            // Instantiate options keeping global properties.
+            for (const breakpoint in map) {
+                if (map.hasOwnProperty(breakpoint)) {
+                    const responsiveOptions = new Options((map as any)[breakpoint]);
+
+                    for (const prop in responsiveOptions) {
+                        if (responsiveOptions.hasOwnProperty(prop) && prop !== "responsive" &&
+                            (responsiveOptions as any)[prop] !== (globalOptions as any)[prop]) {
+                            (responsiveOptions as any)[prop] = (globalOptions as any)[prop];
+                        }
+                    }
+
+                    (this as any)[breakpoint] = responsiveOptions;
                 }
             }
         }


### PR DESCRIPTION
Copy properties from global options when creating ResponsiveMap, so properties set in the global options instance transfer over to responsive options if not explicitly set.

```javascript
var options = {
        dots: true,
        responsive: {
            "0": { count: 1.5, touch: true, buttons: false },
            "480": { count: 2.5, touch: true, buttons: false },
        }
}
```

In the example above, `dots` will be set to `true` in all breakpoints, respecting global property set by user and overriding default value of `false`.